### PR TITLE
core: preserve session model when prompt lacks frontmatter

### DIFF
--- a/codex-rs/core/src/custom_prompts.rs
+++ b/codex-rs/core/src/custom_prompts.rs
@@ -317,8 +317,8 @@ fn is_allowed_model(model: &str) -> bool {
     )
 }
 
-/// Validate a model value parsed from frontmatter. If missing or invalid, return the default.
-/// Logs a warning for invalid values.
+/// Validate a model value parsed from frontmatter. If invalid, fall back to the default.
+/// Missing values propagate `None` so callers can detect when no model was specified.
 fn validate_or_default_model(model: Option<&String>, path: &Path) -> Option<String> {
     match model {
         Some(m) if is_allowed_model(m) => Some(m.clone()),
@@ -331,7 +331,7 @@ fn validate_or_default_model(model: Option<&String>, path: &Path) -> Option<Stri
             );
             Some(default_model_id().to_string())
         }
-        None => Some(default_model_id().to_string()),
+        None => None,
     }
 }
 
@@ -832,9 +832,9 @@ mod tests {
         assert!(out.len() <= 200);
     }
 
-    // T019: Backward compatibility – prompts without frontmatter are unchanged except defaults
+    // T019: Backward compatibility – prompts without frontmatter yield empty meta
     #[tokio::test]
-    async fn no_frontmatter_yields_empty_meta_and_default_model() {
+    async fn no_frontmatter_yields_empty_meta_and_no_model() {
         let fx = PromptFixtures::new();
         fx.write_project("plain.md", "Just content\n");
 
@@ -843,6 +843,6 @@ mod tests {
         let m = meta.iter().find(|m| m.name == "plain").unwrap();
         assert_eq!(m.description.as_deref(), None);
         assert_eq!(m.argument_hint.as_deref(), None);
-        assert_eq!(m.model.as_deref(), Some(super::default_model_id()));
+        assert_eq!(m.model, None);
     }
 }

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -531,9 +531,9 @@ impl ChatComposer {
                                     },
                                 ));
                             }
-                            // Parse `/name …` using the full composer text. Build args from the
-                            // first line remainder; build rest from the remainder plus all
-                            // subsequent lines verbatim.
+                            // Parse `/name …` using the full composer text.
+                            // `args` comes from the remainder of the first line.
+                            // `rest` combines that remainder with all subsequent lines verbatim.
                             let mut args: Vec<String> = Vec::new();
                             let mut rest = String::new();
 
@@ -2239,9 +2239,9 @@ mod tests {
 
     #[test]
     fn argument_hint_placeholder_shows_only_with_single_space() {
-        use crossterm::event::KeyCode;
-        use crossterm::event::KeyEvent;
-        use crossterm::event::KeyModifiers;
+        
+        
+        
 
         let (tx, _rx) = unbounded_channel::<AppEvent>();
         let sender = AppEventSender::new(tx);
@@ -2275,7 +2275,7 @@ mod tests {
         let mut has_hint_for = |text: &str| -> bool {
             composer.set_text_content(text.to_string());
             let mut buf = ratatui::buffer::Buffer::empty(area);
-            (&composer).render_ref(area, &mut buf);
+            composer.render_ref(area, &mut buf);
             let mut acc = String::new();
             for y in 0..area.height {
                 for x in 0..area.width {


### PR DESCRIPTION
## Summary
- avoid defaulting CustomPromptMeta.model to `gpt-5-medium` when frontmatter omits a model
- clarify comment when parsing `/name` custom prompt commands

## Testing
- `cargo clippy -p codex-core`
- `cargo clippy -p codex-tui`
- `cargo test -p codex-core`
- `cargo test -p codex-tui` *(fails: tests hang after compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68be2ac9a1fc832ab9c48449ee0172af