### PR TITLE
core: preserve session model when prompt lacks frontmatter

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -202,6 +202,47 @@ impl App {
                 self.chat_widget = ChatWidget::new(init, self.server.clone());
                 tui.frame_requester().schedule_frame();
             }
+            AppEvent::OpenResumePicker => {
+                match crate::resume_picker::run_resume_picker(tui, &self.config.codex_home).await? {
+                    crate::resume_picker::ResumeSelection::Exit => {
+                        return Ok(false);
+                    }
+                    crate::resume_picker::ResumeSelection::StartFresh => {
+                        let init = crate::chatwidget::ChatWidgetInit {
+                            config: self.config.clone(),
+                            frame_requester: tui.frame_requester(),
+                            app_event_tx: self.app_event_tx.clone(),
+                            initial_prompt: None,
+                            initial_images: Vec::new(),
+                            enhanced_keys_supported: self.enhanced_keys_supported,
+                        };
+                        self.chat_widget = ChatWidget::new(init, self.server.clone());
+                        tui.frame_requester().schedule_frame();
+                    }
+                    crate::resume_picker::ResumeSelection::Resume(path) => {
+                        let mut cfg = self.config.clone();
+                        cfg.experimental_resume = Some(path.clone());
+                        let resumed =
+                            self.server.new_conversation(cfg).await.wrap_err_with(|| {
+                                format!("Failed to resume session from {}", path.display())
+                            })?;
+                        let init = crate::chatwidget::ChatWidgetInit {
+                            config: self.config.clone(),
+                            frame_requester: tui.frame_requester(),
+                            app_event_tx: self.app_event_tx.clone(),
+                            initial_prompt: None,
+                            initial_images: Vec::new(),
+                            enhanced_keys_supported: self.enhanced_keys_supported,
+                        };
+                        self.chat_widget = ChatWidget::new_from_existing(
+                            init,
+                            resumed.conversation,
+                            resumed.session_configured,
+                        );
+                        tui.frame_requester().schedule_frame();
+                    }
+                }
+            }
             AppEvent::InsertHistoryCell(cell) => {
                 let mut cell_transcript = cell.transcript_lines();
                 if !cell.is_stream_continuation() && !self.transcript_lines.is_empty() {

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -16,6 +16,9 @@ pub(crate) enum AppEvent {
     /// Start a new session.
     NewSession,
 
+    /// Open the resume picker and replace the current session based on selection.
+    OpenResumePicker,
+
     /// Request to exit the application gracefully.
     ExitRequest,
 

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -2239,10 +2239,6 @@ mod tests {
 
     #[test]
     fn argument_hint_placeholder_shows_only_with_single_space() {
-        
-        
-        
-
         let (tx, _rx) = unbounded_channel::<AppEvent>();
         let sender = AppEventSender::new(tx);
         let mut composer = ChatComposer::new(

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -831,6 +831,9 @@ impl ChatWidget {
             SlashCommand::New => {
                 self.app_event_tx.send(AppEvent::NewSession);
             }
+            SlashCommand::Resume => {
+                self.app_event_tx.send(AppEvent::OpenResumePicker);
+            }
             SlashCommand::Init => {
                 const INIT_PROMPT: &str = include_str!("../prompt_for_init_command.md");
                 self.submit_text_message(INIT_PROMPT.to_string());

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -637,6 +637,10 @@ pub(crate) fn new_session_info(
             ]));
         }
         lines.push(Line::from(vec![
+            " /resume".bold(),
+            format!(" - {}", SlashCommand::Resume.description()).dim(),
+        ]));
+        lines.push(Line::from(vec![
             " /status".bold(),
             format!(" - {}", SlashCommand::Status.description()).dim(),
         ]));

--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -41,9 +41,10 @@ pub async fn run_resume_picker(tui: &mut Tui, codex_home: &Path) -> Result<Resum
     let alt = AltScreenGuard::enter(tui);
     let mut state = PickerState::new(codex_home.to_path_buf(), alt.tui.frame_requester());
     state.load_page(None).await?;
-    state.request_frame();
-
+    // Subscribe to Draw events before requesting the initial frame to avoid
+    // missing the first render due to the broadcast channel semantics.
     let mut events = alt.tui.event_stream();
+    state.request_frame();
     while let Some(ev) = events.next().await {
         match ev {
             TuiEvent::Key(key) => {

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -15,6 +15,7 @@ pub enum SlashCommand {
     Model,
     Approvals,
     New,
+    Resume,
     Init,
     Compact,
     Diff,
@@ -32,6 +33,7 @@ impl SlashCommand {
     pub fn description(self) -> &'static str {
         match self {
             SlashCommand::New => "start a new chat during a conversation",
+            SlashCommand::Resume => "resume a previous session",
             SlashCommand::Init => "create an AGENTS.md file with instructions for Codex",
             SlashCommand::Compact => "summarize conversation to prevent hitting the context limit",
             SlashCommand::Quit => "exit Codex",
@@ -57,6 +59,7 @@ impl SlashCommand {
     pub fn available_during_task(self) -> bool {
         match self {
             SlashCommand::New
+            | SlashCommand::Resume
             | SlashCommand::Init
             | SlashCommand::Compact
             | SlashCommand::Model


### PR DESCRIPTION
## Summary
- merge base 116c031f80d1ad2a86f39a345777c613e2c8d66e and resolve conflict in chat composer test

## Testing
- `just fmt`
- `just fix -p codex-tui`
- `cargo test -p codex-tui` *(fails: build did not finish; process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68be31892984832ab289bf8682b4e041